### PR TITLE
Explanatory output form ./main run

### DIFF
--- a/base/start.sh
+++ b/base/start.sh
@@ -13,6 +13,8 @@ then
 		if docker container start "${container}"
 		then
 			exit 0
+		else 
+			echo "Starting existing container failed; creating a new one..."
 		fi
 	fi
 	docker container rm -f "${container}"


### PR DESCRIPTION
"Starting existing container failed; creating a new one..."