### PR TITLE
fix Windows bind paths NOTE: set DOCKER_BINDS to /d/fork/docker4gis/b…

### DIFF
--- a/base/cron/run.sh
+++ b/base/cron/run.sh
@@ -17,15 +17,11 @@ GEOSERVER_PASSWORD="${GEOSERVER_PASSWORD:-geoserver}"
 
 if .run/start.sh "${image}" "${container}"; then exit; fi
 
-mkdir -p "${DOCKER_BINDS_DIR}/secrets"
-mkdir -p "${DOCKER_BINDS_DIR}/fileport"
-mkdir -p "${DOCKER_BINDS_DIR}/runner"
-
 docker container run --name $container \
 	-e DOCKER_USER="${DOCKER_USER}" \
-	-v $DOCKER_BINDS_DIR/secrets:/secrets \
-	-v $DOCKER_BINDS_DIR/fileport:/fileport \
-	-v $DOCKER_BINDS_DIR/runner:/util/runner/log \
+	$(docker_bind "${DOCKER_BINDS_DIR}/secrets"  /secrets) \
+	$(docker_bind "${DOCKER_BINDS_DIR}/fileport" /fileport) \
+	$(docker_bind "${DOCKER_BINDS_DIR}/runner"   /util/runner/log) \
 	--network "${DOCKER_USER}" \
 	-e "GEOSERVER_CONTAINER=${GEOSERVER_CONTAINER}" \
 	-e "GEOSERVER_USER=${GEOSERVER_USER}" \

--- a/base/elm/build.sh
+++ b/base/elm/build.sh
@@ -17,7 +17,7 @@ popd
 mkdir -p build
 docker container run \
     --rm \
-    -v $PWD/build:/app/build \
+	$(docker_bind "${PWD}/build" /app/build) \
     elm-app/build
 docker image rm elm-app/build
 

--- a/base/geoserver/run.sh
+++ b/base/geoserver/run.sh
@@ -17,12 +17,6 @@ GEOSERVER_PASSWORD="${GEOSERVER_PASSWORD:-geoserver}"
 
 if .run/start.sh "${image}" "${container}"; then exit; fi
 
-mkdir -p "${DOCKER_BINDS_DIR}/secrets"
-mkdir -p "${DOCKER_BINDS_DIR}/fileport"
-mkdir -p "${DOCKER_BINDS_DIR}/runner"
-mkdir -p "${DOCKER_BINDS_DIR}/certificates"
-mkdir -p "${DOCKER_BINDS_DIR}/gwc"
-
 XMS="${XMS:-256m}"
 XMX="${XMX:-2g}"
 
@@ -35,11 +29,11 @@ docker container run --name "${container}" \
 	-e XMS="${XMS}" \
 	-e XMX="${XMX}" \
 	-e GEOSERVER_HOST=$GEOSERVER_HOST \
-	-v $DOCKER_BINDS_DIR/secrets:/secrets \
-	-v $DOCKER_BINDS_DIR/fileport:/fileport \
-	-v $DOCKER_BINDS_DIR/certificates:/certificates \
-	-v $DOCKER_BINDS_DIR/gwc:/geoserver/cache \
-	-v $DOCKER_BINDS_DIR/runner:/util/runner/log \
+	$(docker_bind "${DOCKER_BINDS_DIR}/secrets"      /secrets) \
+	$(docker_bind "${DOCKER_BINDS_DIR}/certificates" /certificates) \
+	$(docker_bind "${DOCKER_BINDS_DIR}/fileport"     /fileport) \
+	$(docker_bind "${DOCKER_BINDS_DIR}/runner"       /util/runner/log) \
+	$(docker_bind "${DOCKER_BINDS_DIR}/gwc"          /geoserver/cache) \
 	--mount source="${container}",target=/geoserver/data/workspaces/dynamic \
 	--network "${DOCKER_USER}" \
 	-e "GEOSERVER_USER=${GEOSERVER_USER}" \

--- a/base/glassfish/build.sh
+++ b/base/glassfish/build.sh
@@ -25,7 +25,7 @@ if [ "${war}" != 'war' ]; then
     fi
 
     docker container run --rm \
-        -v "${src_dir}":/src \
+    	$(docker_bind "${src_dir}" /src) \
         --mount source=mvndata,target="${cache_dir}" \
         dirichlet/netbeans \
         bash -c '\

--- a/base/glassfish/run.sh
+++ b/base/glassfish/run.sh
@@ -21,7 +21,7 @@ docker container run --name "${container}" \
 	-e DOCKER_USER="${DOCKER_USER}" \
 	--network "${DOCKER_USER}" \
 	--mount source="${container}",target=/host \
-	-v $DOCKER_BINDS_DIR/fileport:/fileport \
+	$(docker_bind "${DOCKER_BINDS_DIR}/fileport" /fileport) \
 	-p "${app_port}":8080 \
 	-p "${admin_port}":4848 \
 	"$@" \

--- a/base/maven/base/run.sh
+++ b/base/maven/base/run.sh
@@ -8,6 +8,6 @@ echo; echo "Compiling from '${src_dir}'..."
 docker volume create mvndata
 
 docker container run --rm \
-    -v "${src_dir}":/src \
+	$(docker_bind "${src_dir}" /src) \
     --mount source=mvndata,target=/root/.m2 \
     "docker4gis/maven:${maven_tag}"

--- a/base/mysql/run.sh
+++ b/base/mysql/run.sh
@@ -17,10 +17,6 @@ SECRET="${SECRET}"
 
 if .run/start.sh "${image}" "${container}"; then exit; fi
 
-mkdir -p "${DOCKER_BINDS_DIR}/secrets"
-mkdir -p "${DOCKER_BINDS_DIR}/fileport"
-mkdir -p "${DOCKER_BINDS_DIR}/runner"
-
 gateway=$(docker network inspect "${DOCKER_USER}" | grep 'Gateway' | grep -oP '\d+\.\d+\.\d+\.\d+')
 
 MYSQL_PORT=$(.run/port.sh "${MYSQL_PORT:-3306}")
@@ -34,9 +30,9 @@ docker container run --name $container \
 	-e MYSQL_DATABASE=$MYSQL_DATABASE \
 	-e CONTAINER=$container \
 	-e GATEWAY=$gateway \
-	-v $DOCKER_BINDS_DIR/secrets:/secrets \
-	-v $DOCKER_BINDS_DIR/fileport:/fileport \
-	-v $DOCKER_BINDS_DIR/runner:/util/runner/log \
+	$(docker_bind "${DOCKER_BINDS_DIR}/secrets"  /secrets) \
+	$(docker_bind "${DOCKER_BINDS_DIR}/fileport" /fileport) \
+	$(docker_bind "${DOCKER_BINDS_DIR}/runner"   /util/runner/log) \
 	--mount source="$container",target=/var/lib/mysql \
 	-p "${MYSQL_PORT}":3306 \
 	--network "${DOCKER_USER}" \

--- a/base/package/run.sh
+++ b/base/package/run.sh
@@ -24,6 +24,19 @@ then
 	popd
 fi
 
+docker_bind() {
+	source="$1"
+	target="$2"
+	mkdir -p "${source}"
+	if [ "${OS}" = "Windows_NT" ]
+	then
+		source="/${source}"
+	fi
+	# echo --mount "type=bind,source=${source},target=${target}"
+	echo -v "${source}:${target}"
+}
+export -f docker_bind
+
 echo "
 $(date)
 

--- a/base/postfix/run.sh
+++ b/base/postfix/run.sh
@@ -15,9 +15,6 @@ POSTFIX_DESTINATION="${POSTFIX_DESTINATION}"
 
 if .run/start.sh "${image}" "${container}"; then exit; fi
 
-mkdir -p "${DOCKER_BINDS_DIR}/fileport"
-mkdir -p "${DOCKER_BINDS_DIR}/runner"
-
 destination=
 if [ "${POSTFIX_DESTINATION}" != '' ]; then
 	destination="-e DESTINATION=${POSTFIX_DESTINATION}"
@@ -27,8 +24,8 @@ POSTFIX_PORT=$(.run/port.sh "${POSTFIX_PORT:-25}")
 
 docker container run --name $container \
 	-e DOCKER_USER="${DOCKER_USER}" \
-	-v $DOCKER_BINDS_DIR/fileport:/fileport \
-	-v $DOCKER_BINDS_DIR/runner:/util/runner/log \
+	$(docker_bind "${DOCKER_BINDS_DIR}/fileport" /fileport) \
+	$(docker_bind "${DOCKER_BINDS_DIR}/runner"   /util/runner/log) \
 	-p "${POSTFIX_PORT}":25 \
 	${destination} \
 	--network "${DOCKER_USER}" \

--- a/base/postgis/run.sh
+++ b/base/postgis/run.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -x
 
 POSTGRES_USER="${1:-postgres}"
 POSTGRES_PASSWORD="${2:-postgres}"
@@ -18,11 +19,6 @@ SECRET="${SECRET}"
 
 if .run/start.sh "${image}" "${container}"; then exit; fi
 
-mkdir -p "${DOCKER_BINDS_DIR}/secrets"
-mkdir -p "${DOCKER_BINDS_DIR}/fileport"
-mkdir -p "${DOCKER_BINDS_DIR}/runner"
-mkdir -p "${DOCKER_BINDS_DIR}/certificates"
-
 postfix_domain=
 if [ "${POSTFIX_DOMAIN}" != '' ]; then
 	postfix_domain="-e POSTFIX_DOMAIN=${POSTFIX_DOMAIN}"
@@ -41,10 +37,10 @@ docker container run --name $container \
 	-e POSTGRES_USER=$POSTGRES_USER \
 	-e POSTGIS_HOST=$POSTGIS_HOST \
 	-e CONTAINER=$container \
-	-v $DOCKER_BINDS_DIR/secrets:/secrets \
-	-v $DOCKER_BINDS_DIR/certificates:/certificates \
-	-v $DOCKER_BINDS_DIR/fileport:/fileport \
-	-v $DOCKER_BINDS_DIR/runner:/util/runner/log \
+	$(docker_bind "${DOCKER_BINDS_DIR}/secrets"      /secrets) \
+	$(docker_bind "${DOCKER_BINDS_DIR}/certificates" /certificates) \
+	$(docker_bind "${DOCKER_BINDS_DIR}/fileport"     /fileport) \
+	$(docker_bind "${DOCKER_BINDS_DIR}/runner"       /util/runner/log) \
 	--mount source="$container",target=/var/lib/postgresql/data \
 	-p "${POSTGIS_PORT}":5432 \
 	--network "${DOCKER_USER}" \

--- a/base/proxy/build.sh
+++ b/base/proxy/build.sh
@@ -14,7 +14,7 @@ HERE=$(dirname "$0")
 if [ -d goproxy ]; then # building base
 	export MSYS_NO_PATHCONV=1
 	if docker container run --rm \
-		-v "$PWD"/goproxy:/usr/src/goproxy \
+		$(docker_bind "${PWD}/goproxy" /usr/src/goproxy) \
 		-w /usr/src/goproxy \
 		-e CGO_ENABLED=0 \
 		-e GOOS=linux \

--- a/base/proxy/run.sh
+++ b/base/proxy/run.sh
@@ -49,8 +49,6 @@ urlhost()
 	echo "${1}" | sed 's~.*//\([^:/]*\).*~\1~'
 }
 
-mkdir -p "${DOCKER_BINDS_DIR}/certificates"
-
 network="${container}"
 .run/network.sh "${network}"
 
@@ -64,7 +62,7 @@ docker container run --name "${container}" \
 	-e PROXY_HOST=$PROXY_HOST \
 	-e PROXY_PORT=$PROXY_PORT \
 	$(secret) $(api) $(app) $(homedest) \
-	-v $DOCKER_BINDS_DIR/certificates:/certificates \
+	$(docker_bind "${DOCKER_BINDS_DIR}/certificates" /certificates) \
 	--mount source="${volume}",target=/config \
 	-p "${PROXY_PORT}":443 \
 	-p "${PROXY_PORT_HTTP}":80 \

--- a/base/serve/run.sh
+++ b/base/serve/run.sh
@@ -14,10 +14,9 @@ image="${DOCKER_REGISTRY}${DOCKER_USER}/${repo}:${DOCKER_TAG}"
 if .run/start.sh "${image}" "${container}"; then exit; fi
 
 fileport="${DOCKER_BINDS_DIR}/fileport/${DOCKER_USER}"
-mkdir -p "${fileport}"
 
 docker container run --name $container \
 	-e DOCKER_USER="${DOCKER_USER}" \
 	--network "${DOCKER_USER}" \
-	-v "${fileport}":/fileport \
+	$(docker_bind "${fileport}" /fileport) \
 	-d $image serve "$@"

--- a/base/tomcat/run.sh
+++ b/base/tomcat/run.sh
@@ -13,10 +13,6 @@ image="${DOCKER_REGISTRY}${DOCKER_USER}/${repo}:${DOCKER_TAG}"
 
 if .run/start.sh "${image}" "${container}"; then exit; fi
 
-mkdir -p "${DOCKER_BINDS_DIR}/fileport"
-mkdir -p "${DOCKER_BINDS_DIR}/secrets"
-mkdir -p "${DOCKER_BINDS_DIR}/runner"
-
 XMS="${XMS:-256m}"
 XMX="${XMX:-2g}"
 
@@ -29,9 +25,9 @@ docker container run --name $container \
 	-e XMS="${XMS}" \
 	-e XMX="${XMX}" \
 	--mount source="${container}",target=/host \
-	-v $DOCKER_BINDS_DIR/fileport:/fileport \
-	-v $DOCKER_BINDS_DIR/secrets:/secrets \
-	-v $DOCKER_BINDS_DIR/runner:/util/runner/log \
+	$(docker_bind "${DOCKER_BINDS_DIR}/secrets"  /secrets) \
+	$(docker_bind "${DOCKER_BINDS_DIR}/fileport" /fileport) \
+	$(docker_bind "${DOCKER_BINDS_DIR}/runner"   /util/runner/log) \
 	--network "${DOCKER_USER}" \
 	-p "${TOMCAT_PORT}":8080 \
 	"$@" \


### PR DESCRIPTION
…ase format

Docker Desktop 2.2.0.0 -> 2.2.0.3 broke support for
D:\fork\docker4gis\base/../binds format
also doesn't take
/d/fork/docker4gis/base/../binds
only
//d/fork/docker4gis/base/../binds