### PR TITLE
proxy: rewrite set-cookie domain, path

### DIFF
--- a/templates/proxy/Dockerfile
+++ b/templates/proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker4gis/proxy:311
+FROM docker4gis/proxy:312
 
 # These default values are overwritten by run time environment values, if set:
 ENV API="http://$DOCKER_USER-api:8080/"


### PR DESCRIPTION
Use a dynamic proxy instance, allowing access to the original
request URL from the ModifyResponse function, to dynamically
rewrite Domain and Path values of the Response's cookies.