### PR TITLE
proxy: authorise: substitute more generically

### DIFF
--- a/templates/proxy/Dockerfile
+++ b/templates/proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker4gis/proxy:325
+FROM docker4gis/proxy:328
 
 # These default values are overwritten by run time environment values, if set:
 ENV API="http://$DOCKER_USER-api:8080/"


### PR DESCRIPTION
make less assumptions; leave any specific escaping
to the AuthPath endpoint