### PR TITLE
mkdir -p "$DOCKER_BINDS_DIR"/fileport/"$DOCKER_USER"

### DIFF
--- a/base/.docker4gis/docker4gis/run.sh
+++ b/base/.docker4gis/docker4gis/run.sh
@@ -14,6 +14,10 @@ export DOCKER_ENV
     RESTART=always
 export RESTART
 
+# create before running any container, to have this owned by the user running
+# the run script (instead of a container's root user)
+mkdir -p "$DOCKER_BINDS_DIR"/fileport/"$DOCKER_USER"
+
 IMAGE=$DOCKER_REGISTRY$DOCKER_USER/$repo:$tag
 export IMAGE
 [ "$repo" = proxy ] &&

--- a/templates/postfix/Dockerfile
+++ b/templates/postfix/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker4gis/postfix:333
+FROM docker4gis/postfix:331
 
 ENV DESTINATION=example.com
 # And/or set POSTFIX_DESTINATION at run time


### PR DESCRIPTION
# create before running any container, to have this owned by the user running
# the run script (instead of a container's root user)