### PR TITLE
fix: prevent unwanted ${DOCKER_USER}-docker4gis-proxy component in dg…

### DIFF
--- a/packages/docker4gis-cli/devops/conf/components.sh
+++ b/packages/docker4gis-cli/devops/conf/components.sh
@@ -358,11 +358,18 @@ normalise_component_name() {
         echo "$comp"
         return 0
     }
-    [[ "$comp" == docker4gis-* ]] || comp="docker4gis-$comp"
-    echo "$comp"
+    # Strip base-image docker4gis- prefix.
+    comp=${comp#docker4gis-}
+    if [ -n "$DOCKER_USER" ]; then
+        # Strip existing DOCKER_USER- prefix to avoid double-prefixing.
+        comp=${comp#"$DOCKER_USER"-}
+        echo "$DOCKER_USER-$comp"
+    else
+        echo "docker4gis-$comp"
+    fi
 }
 
-non_package_components=(docker4gis-proxy)
+non_package_components=("$(normalise_component_name proxy)")
 for c in "$@"; do
     IFS='=' read -r comp _ <<<"$c"
     comp=$(normalise_component_name "$comp")


### PR DESCRIPTION
… devops

normalise_component_name was prefixing with docker4gis- while the monorepo directory convention (component_dir_name) uses ${DOCKER_USER}-. This caused the directory check to always miss, dg component docker4gis-proxy to be called, and component_dir_name to double-prefix it to ${DOCKER_USER}-docker4gis-proxy.