### PR TITLE
fix(pipeline): skip sparse checkout for package component pipelines

### DIFF
--- a/packages/docker4gis-cli/docker4gis
+++ b/packages/docker4gis-cli/docker4gis
@@ -125,7 +125,9 @@ pipeline() {
 
         # Ensure all generated pipelines use a shallow checkout.
         login_steps=$'- checkout: self\n  fetchDepth: 1\n'
-        login_steps+=$'  sparseCheckoutDirectories: components/'"$dir_name"$'\n'
+        # Package pipelines need all sibling components, so no sparse checkout.
+        [ "$is_package" ] ||
+            login_steps+=$'  sparseCheckoutDirectories: components/'"$dir_name"$'\n'
         login_steps+=$'  displayName: Git checkout\n'
 
         [ "$file" = "$continuous_integration" ] && {
@@ -146,7 +148,9 @@ pipeline() {
             login_steps=$'- checkout: self\n'
             login_steps+=$'  persistCredentials: true\n'
             login_steps+=$'  fetchDepth: 1\n'
-            login_steps+=$'  sparseCheckoutDirectories: components/'"$dir_name"$'\n'
+            # Package pipelines need all sibling components, so no sparse checkout.
+            [ "$is_package" ] ||
+                login_steps+=$'  sparseCheckoutDirectories: components/'"$dir_name"$'\n'
             login_steps+="  displayName: Git login
 "
         }


### PR DESCRIPTION
The package component needs access to all sibling components at build time, so its generated pipelines must not restrict checkout to a single component directory.