### PR TITLE
feat(cli): pass component .env vars into container

### DIFF
--- a/packages/docker4gis-cli/base/.docker4gis/docker4gis/run.sh
+++ b/packages/docker4gis-cli/base/.docker4gis/docker4gis/run.sh
@@ -69,6 +69,16 @@ DOCKER_CONTAINER=$DOCKER_CONTAINER
 DOCKER_NETWORK=$DOCKER_NETWORK
 DOCKER_VOLUME=$DOCKER_VOLUME
 DEBUG=$DEBUG" >>"$ENV_FILE"
+
+# Append the component's .env so any variable defined there flows into the
+# container.
+_dotenv_file="$DOCKER4GIS_COMPONENT_DIR/.env"
+if [ -f "$_dotenv_file" ]; then
+    grep -v '^[[:space:]]*#' "$_dotenv_file" |
+        grep -v '^[[:space:]]*$' >>"$ENV_FILE"
+fi
+unset _dotenv_file
+
 export ENV_FILE
 
 # Write environment variables having the "${DOCKER_USER}_${DOCKER_REPO}_" prefix

--- a/packages/docker4gis-cli/base/.docker4gis/run
+++ b/packages/docker4gis-cli/base/.docker4gis/run
@@ -28,12 +28,13 @@ echo "
 (
     export DOCKER_REGISTRY=$DOCKER_REGISTRY
     export DOCKER_USER=$DOCKER_USER
+    component_dir=\$(pwd) &&
     temp=\$(mktemp -d) &&
         dummy=\$(docker container create '$DOCKER_IMAGE') &&
         docker container cp \"\$dummy\":/.docker4gis \"\$temp\" >/dev/null &&
         docker container rm \"\$dummy\" >/dev/null &&
         cd \"\$temp\"/.docker4gis &&
-        docker4gis/run.sh '$DOCKER_REPO' '$DOCKER_TAG'
+        DOCKER4GIS_COMPONENT_DIR=\"\$component_dir\" docker4gis/run.sh '$DOCKER_REPO' '$DOCKER_TAG'
     result=\$?
     rm -rf \"\$temp\"
     exit \$result


### PR DESCRIPTION
Capture the component directory before cd-ing to the temp dir in the eval'd run script, then append the component's .env to ENV_FILE in docker4gis/run.sh so any plain KEY=value defined there flows into the container without needing the DOCKER_USER_REPO_ prefix or explicit --env flags in component run scripts.