### PR TITLE
fix(run): resolve ^package dir when invoked from a component directory

### DIFF
--- a/packages/docker4gis-cli/base/main.sh
+++ b/packages/docker4gis-cli/base/main.sh
@@ -107,6 +107,15 @@ dir() {
 			[ -f "$dir_found" ] && break
 		done
 
+		# Also check sibling components (when running from inside a component).
+		if ! [ -f "$dir_found" ]; then
+			for env_file in ../../components/*/.env; do
+				[ -f "$env_file" ] || break
+				run_in_env_file "$env_file" "$@"
+				[ -f "$dir_found" ] && break
+			done
+		fi
+
 		# Also check the monorepo package root (two levels up, from a component).
 		[ -f "$dir_found" ] || run_in_env_file "../../.env" "$@"
 


### PR DESCRIPTION
When `dg run` is issued from inside a component directory, `dir package` failed to locate ^package because it only searched `./components/` (not present in a component dir) and `../../.env` (the monorepo root, which has no DOCKER_REPO=package). As a result, list.sh ran from the component directory and wrote/read version-tracking files under the wrong `./components/` path.

Fix: also search `../../components/*/.env` (sibling components) so that ^package is found and the shell re-enters from there before list.sh runs.